### PR TITLE
Améliorer le lien de retour dans le header Agentic Commerce

### DIFF
--- a/src/components/agentic-commerce/Header.tsx
+++ b/src/components/agentic-commerce/Header.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
 import type { Locale } from "@/lib/agentic-commerce/i18n/config";
 import type { Dictionary } from "@/lib/agentic-commerce/i18n/dictionaries/en";
 import BoostAIMark from "@/components/brand/BoostAIMark";
@@ -56,10 +57,11 @@ export function AgenticHeader({ locale, dict }: Props) {
         <div className="flex items-center gap-2 sm:gap-3">
           <Link
             to="/"
-            className="hidden rounded-full px-3 py-1.5 text-sm font-semibold text-ac-muted transition-colors hover:text-ac-primary lg:inline"
+            className="flex items-center gap-1.5 rounded-full border border-ac-muted/20 bg-white/30 px-3 py-1.5 text-sm font-semibold text-ac-on-surface shadow-sm transition-all hover:border-ac-primary/30 hover:bg-white/50 hover:text-ac-primary"
             onClick={() => trackAgenticEvent("nav_home", { locale })}
           >
-            {dict.nav.homeLabel}
+            <ArrowLeft className="h-4 w-4" />
+            <span className="hidden sm:inline">{dict.nav.homeLabel}</span>
           </Link>
           <Link
             to={dict.nav.switchHref}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Amélioration du header de la page Agentic Commerce pour rendre le retour vers BoostAI plus visible et intuitif.

## Changements

- ✨ Ajout d'une icône de flèche (`ArrowLeft`) pour indiquer clairement le retour
- 🎨 Stylisation du bouton avec bordure et fond pour le faire ressortir
- 📱 Visible sur tous les écrans (icône toujours visible, texte à partir de `sm`)
- 🎯 Meilleurs effets de hover avec transition fluide

## Avant / Après

**Avant** : Le lien "BoostAI Consulting" était caché sur les écrans < lg, peu visible

**Après** : Bouton stylisé avec icône flèche, visible sur tous les écrans, clairement identifiable comme lien de retour

## Design

Le bouton a maintenant :
- Une bordure subtile
- Un fond blanc semi-transparent
- Une icône de flèche à gauche
- Des effets de hover élégants
- Visible sur mobile (icône seule) et desktop (icône + texte)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa9e6-0abf-735b-832a-f13230ae9db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa9e6-0abf-735b-832a-f13230ae9db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

